### PR TITLE
알람뷰 글씨색깔, layout(반응형), 클릭이벤트 수정

### DIFF
--- a/Projects/DonWorry/Sources/UI/AlertView/UI/AlertViewViewController.swift
+++ b/Projects/DonWorry/Sources/UI/AlertView/UI/AlertViewViewController.swift
@@ -85,10 +85,11 @@ extension AlertViewViewController: UITableViewDataSource, UITableViewDelegate {
         
         let messageTuple = viewModel.sortedMessages[indexPath.section]
         cell.configure(message: messageTuple[indexPath.row])
+        cell.selectionStyle = .none
         
         return cell
     }
-    
+
     func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
         return 10.0
     }

--- a/Projects/DonWorry/Sources/UI/AlertView/UI/Views/AlertTableViewCell.swift
+++ b/Projects/DonWorry/Sources/UI/AlertView/UI/Views/AlertTableViewCell.swift
@@ -32,6 +32,7 @@ class AlertTableViewCell: BaseTableViewCell {
         let spaceName = UILabel()
         spaceName.translatesAutoresizingMaskIntoConstraints = false
         spaceName.font = .designSystem(weight: .heavy, size: ._15)
+        spaceName.textColor = .designSystem(.black)
         return spaceName
     }()
     
@@ -39,13 +40,14 @@ class AlertTableViewCell: BaseTableViewCell {
         let alertInfo = UILabel()
         alertInfo.translatesAutoresizingMaskIntoConstraints = false
         alertInfo.font = .designSystem(weight: .regular, size: ._13)
-        alertInfo.textColor = .designSystem(.grayF6F6F6)
+        alertInfo.textColor = .designSystem(.gray818181)
         return alertInfo
     }()
     
     private let goToPayment: UIImageView = {
         let goToPayment = UIImageView()
-        goToPayment.frame = CGRect(x: 300, y: 25, width: 72, height: 33)
+//        goToPayment.frame = CGRect(x: 300, y: 25, width: 72, height: 33)
+        goToPayment.translatesAutoresizingMaskIntoConstraints = false
         goToPayment.backgroundColor = .designSystem(.mainBlue)
         goToPayment.layer.cornerRadius = 16.5
         goToPayment.isHidden = true
@@ -89,6 +91,11 @@ class AlertTableViewCell: BaseTableViewCell {
         alertInfo.leadingAnchor.constraint(equalTo: smallRectangele.trailingAnchor, constant: 10).isActive = true
         
         contentView.addSubview(goToPayment)
+        goToPayment.centerYAnchor.constraint(equalTo: contentView.centerYAnchor).isActive = true
+        goToPayment.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -40).isActive = true
+        goToPayment.widthAnchor.constraint(equalToConstant: 72).isActive = true
+        goToPayment.heightAnchor.constraint(equalToConstant: 33).isActive = true
+        
         goToPayment.addSubview(buttonLabel)
         buttonLabel.centerYAnchor.constraint(equalTo: goToPayment.centerYAnchor).isActive = true
         buttonLabel.centerXAnchor.constraint(equalTo: goToPayment.centerXAnchor).isActive = true
@@ -111,7 +118,7 @@ class AlertTableViewCell: BaseTableViewCell {
             iconImage.heightAnchor.constraint(equalToConstant: 24).isActive = true
             goToPayment.isHidden = false
             if message.isCompleted {
-                goToPayment.backgroundColor = .designSystem(.grayF6F6F6)
+                goToPayment.backgroundColor = .designSystem(.grayC5C5C5)
                 buttonLabel.text = "완료"
                 buttonLabel.textColor = .designSystem(.white)
             }


### PR DESCRIPTION
## 개요🔍
- 글씨색깔 수정
- 큰화면에서도 어색하지않게 오토레이아웃수정
- 클릭시 어떤화면이 나오는지 기획이없어서 클릭되지 않게 수정

## 작업사항 📝
- textcolor수정
- 오토레이아웃 수정
- 아직 알람을 누르면 어떤 화면이 뜨는지가 정해지지 않아서 터치이벤트 없이 구현(추후 수정예정)

## 스크린샷 📸
왼쪽 13proMax 오른쪽 13mini
<img width="937" alt="스크린샷 2022-09-04 오후 2 45 29" src="https://user-images.githubusercontent.com/99013115/188299384-bf86d06f-4b43-4042-8426-c8a0c0dc1331.png">

