### PR TITLE
✨Admin 아닐 시 정산방 이름 변경 화면으로 이동 불가

### DIFF
--- a/Projects/DonWorry/Sources/UI/PaymentCardList/PaymentCardListReactor.swift
+++ b/Projects/DonWorry/Sources/UI/PaymentCardList/PaymentCardListReactor.swift
@@ -16,7 +16,7 @@ enum PaymentCardListStep {
 
     case pop
     case paymentCardDetail(PaymentCardCellViewModel, IsCardAdmin, String)
-    case actionSheet
+    case actionSheet(Bool)
     case nameEdit
     case addPaymentCard
     case participate
@@ -99,7 +99,7 @@ final class PaymentCardListReactor: Reactor {
             let detailCard = requestIsUserCardAdmin(card: card)
             return detailCard
         case .didTapOptionButton:
-            return .just(.routeTo(.actionSheet))
+            return .just(.routeTo(.actionSheet(currentState.isUserAdmin)))
         case .routeToNameEdit:
             return .just(.routeTo(.nameEdit))
         case .didTapLeaveButton:

--- a/Projects/DonWorry/Sources/UI/PaymentCardList/PaymentCardListViewController.swift
+++ b/Projects/DonWorry/Sources/UI/PaymentCardList/PaymentCardListViewController.swift
@@ -359,8 +359,8 @@ extension PaymentCardListViewController {
                 }
             )
             self.navigationController?.pushViewController(detailViewController, animated: true)
-        case .actionSheet:
-            self.present(optionAlertController(), animated: true)
+        case .actionSheet(let isAdmin):
+            self.present(optionAlertController(isAdmin), animated: true)
         case .nameEdit:
             let editRoomNameViewController = SpaceNameViewController()
             editRoomNameViewController.reactor = SpaceNameReactor(type: .rename(reactor!.currentState.space.id))
@@ -402,13 +402,18 @@ extension PaymentCardListViewController {
         return createCard
     }
     
-    private func optionAlertController() -> UIAlertController {
+    private func optionAlertController(_ isAdmin: Bool) -> UIAlertController {
         let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-        let item1 = UIAlertAction(title: "정산방 이름 변경", style: .default) { _ in
-            self.dismiss(animated: true) { [weak self] in
-                self?.reactor?.action.onNext(.routeToNameEdit)
+        
+        if isAdmin {
+            let item1 = UIAlertAction(title: "정산방 이름 변경", style: .default) { _ in
+                self.dismiss(animated: true) { [weak self] in
+                    self?.reactor?.action.onNext(.routeToNameEdit)
+                }
             }
+            actionSheet.addAction(item1)
         }
+        
         let item2 = UIAlertAction(title: "정산방 나가기", style: .default) { _ in
             self.dismiss(animated: true) { [weak self] in
                 self?.reactor?.action.onNext(.didTapLeaveButton)
@@ -416,7 +421,6 @@ extension PaymentCardListViewController {
         }
         let cancel = UIAlertAction(title: "취소", style: .cancel)
 
-        actionSheet.addAction(item1)
         actionSheet.addAction(item2)
         actionSheet.addAction(cancel)
         return actionSheet

--- a/Projects/DonWorry/Sources/UI/SpaceName/SpaceNameReactor.swift
+++ b/Projects/DonWorry/Sources/UI/SpaceName/SpaceNameReactor.swift
@@ -113,7 +113,7 @@ final class SpaceNameReactor: Reactor {
     private func buttonText(of type: RoomNameEditViewType) -> String {
         switch type {
         case .create:
-            return "정산방 참가하기"
+            return "정산방 생성하기"
         case .rename:
             return "완료"
         }


### PR DESCRIPTION
## 작업사항 📝
- 정산방 admin이 아닐 시 액션시트에서 정산방 이름 변경을 제거하였습니다.
- 정산방 생성 시 버튼 이름을 '정산방 참가하기'에서 '정산방 생성하기'로 수정하였습니다.


## 스크린샷 📸
| Admin일 때 | Admin 아닐 때 |
| ----- | ----- | 
| <img src="https://user-images.githubusercontent.com/88371913/192253197-d644bf8d-41f3-4c2f-80c3-d75585633921.png" width="300"> | <img src="https://user-images.githubusercontent.com/88371913/192252807-3557f42b-6b7b-4ae6-bc5c-e362b6e45322.png" width="300"> |

