### PR TITLE
🚀 탈퇴한 유저 닉네임 null값 API 변경에 대응

### DIFF
--- a/Projects/DonWorry/Sources/Domain/Auth/Repository/AuthRepository.swift
+++ b/Projects/DonWorry/Sources/Domain/Auth/Repository/AuthRepository.swift
@@ -180,9 +180,9 @@ final class AuthRepositoryImpl: AuthRepository {
                 id: dto.id,
                 nickName: dto.nickname,
                 bankAccount: .init(
-                    bank: dto.account.bank,
-                    accountHolderName: dto.account.holder,
-                    accountNumber: dto.account.number
+                    bank: dto.account?.bank ?? ErrorText.DeRegister.bank,
+                    accountHolderName: dto.account?.holder ?? ErrorText.DeRegister.bankHolder,
+                    accountNumber: dto.account?.number ?? ErrorText.DeRegister.bankNumber
                 ),
                 image: dto.imgUrl ?? ""
             )

--- a/Projects/DonWorry/Sources/Domain/Auth/Repository/UserRepository.swift
+++ b/Projects/DonWorry/Sources/Domain/Auth/Repository/UserRepository.swift
@@ -75,13 +75,23 @@ extension UserRepository {
   
     
     fileprivate func convertToUser(userDTO dto: DTO.PostUser) -> Models.User {
-        return .init(id: dto.id, nickName: dto.nickname, bankAccount: .init(bank: dto.account.bank, accountHolderName: dto.account.holder, accountNumber: dto.account.number), image: dto.imgUrl ?? "")
+        return .init(
+            id: dto.id,
+            nickName: dto.nickname,
+            bankAccount: .init(
+                bank: dto.account?.bank ?? ErrorText.DeRegister.bank,
+                accountHolderName: dto.account?.holder ?? ErrorText.DeRegister.bankHolder,
+                accountNumber: dto.account?.number ?? ErrorText.DeRegister.bankNumber
+            ),
+            image: dto.imgUrl ?? "")
     }
     
     fileprivate func convertToUser(patchUserDTO dto: DTO.PatchUser) -> Models.User {
-        let bankAccount = BankAccount(bank: dto.account.bank,
-                                      accountHolderName: dto.account.holder,
-                                      accountNumber: dto.account.number)
+        let bankAccount = BankAccount(
+            bank: dto.account.bank ?? ErrorText.DeRegister.bank,
+            accountHolderName: dto.account.holder ?? ErrorText.DeRegister.bankHolder,
+            accountNumber: dto.account.number ?? ErrorText.DeRegister.bankNumber
+        )
         return .init(id: dto.id, nickName: dto.nickname, bankAccount: bankAccount, image: dto.imgUrl ?? "")
     }
 

--- a/Projects/DonWorry/Sources/Domain/Payment/Repository/PaymentRepository.swift
+++ b/Projects/DonWorry/Sources/Domain/Payment/Repository/PaymentRepository.swift
@@ -42,10 +42,49 @@ final class PaymentRepositoryImpl: PaymentRepository {
     }
     
     private func convertToGiverPayment(_ dto: DTO.GetPaymentsGiver) -> PaymentModels.FetchGiverPayment.Response {
-        return .init(paymentID: dto.paymentID, spaceID: dto.spaceID, amount: dto.amount, spaceTotalAmount: dto.totalAmount, isCompleted: dto.isCompleted, takerNickname: dto.takerNickname, account: .init(bank: dto.account.bank, number: dto.account.number, holder: dto.account.holder), cards: dto.cards.map { .init(name: $0.name, paymentDate: $0.paymentDate, categoryImgURL: $0.categoryImgURL, totalAmount: $0.totalAmount, cardJoinUserCount: $0.cardJoinUserCount, amountPerUser: $0.amountPerUser)}, payments: dto.payments.map { .init(id: $0.id, amount: $0.amount, isCompleted: $0.isCompleted, takerNickname: $0.takerNickname)})
+        return .init(
+            paymentID: dto.paymentID,
+            spaceID: dto.spaceID,
+            amount: dto.amount,
+            spaceTotalAmount: dto.totalAmount,
+            isCompleted: dto.isCompleted,
+            takerNickname: dto.takerNickname,
+            account: .init(
+                bank: dto.account?.bank ?? ErrorText.DeRegister.bank,
+                number: dto.account?.number ?? ErrorText.DeRegister.bankNumber,
+                holder: dto.account?.holder ?? ErrorText.DeRegister.bankHolder
+            ),
+            cards: dto.cards.map { .init(
+                name: $0.name,
+                paymentDate: $0.paymentDate,
+                categoryImgURL: $0.categoryImgURL,
+                totalAmount: $0.totalAmount,
+                cardJoinUserCount: $0.cardJoinUserCount,
+                amountPerUser: $0.amountPerUser
+            )},
+            payments: dto.payments.map { .init(
+                id: $0.id,
+                amount: $0.amount,
+                isCompleted: $0.isCompleted,
+                takerNickname: $0.takerNickname ?? ErrorText.DeRegister.nickname
+            )}
+        )
     }
 
     private func convertToTakerPaymentList(_ dto: DTO.GetPaymentsTaker) -> PaymentModels.FetchTakerPaymentList.Response {
-        return .init(totalAmount: dto.totalAmount, currentAmount: dto.currentAmount, payments: dto.payments.map { .init(id: $0.id, amount: $0.amount, isCompleted: $0.isCompleted, user: .init(id: $0.user.id, nickname: $0.user.nickname, imgURL: $0.user.imgURL))})
+        return .init(
+            totalAmount: dto.totalAmount,
+            currentAmount: dto.currentAmount,
+            payments: dto.payments.map { .init(
+                id: $0.id,
+                amount: $0.amount,
+                isCompleted: $0.isCompleted,
+                user: .init(
+                    id: $0.user.id,
+                    nickname: $0.user.nickname ?? ErrorText.DeRegister.nickname,
+                    imgURL: $0.user.imgURL
+                ))
+            }
+        )
     }
 }

--- a/Projects/DonWorry/Sources/Domain/PaymentCard/Repository/PaymentCardRepository.swift
+++ b/Projects/DonWorry/Sources/Domain/PaymentCard/Repository/PaymentCardRepository.swift
@@ -101,22 +101,46 @@ final class PaymentCardRepositoryImpl: PaymentCardRepository {
             bgColor: dto.bgColor,
             paymentDate: dto.paymentDate,
             category: .init(id: dto.category.id, name: dto.category.name, imgURL: dto.category.imgURL),
-            account: .init(bank: dto.account.bank, number: dto.account.number, holder: dto.account.holder),
-            taker: .init(id: dto.taker.id, nickname: dto.taker.nickname, imgURL: dto.taker.imgURL),
-            givers: dto.givers.map { .init(id: $0.id, nickname: $0.nickname, imgURL: $0.imgURL) },
+            account: .init(
+                bank: dto.account?.bank ?? ErrorText.DeRegister.bank,
+                number: dto.account?.number ?? ErrorText.DeRegister.bankNumber,
+                holder: dto.account?.holder ?? ErrorText.DeRegister.bankHolder
+            ),
+            taker: .init(
+                id: dto.taker.id,
+                nickname: dto.taker.nickname ?? ErrorText.DeRegister.nickname,
+                imgURL: dto.taker.imgURL
+            ),
+            givers: dto.givers.map { .init(
+                id: $0.id,
+                nickname: $0.nickname ?? ErrorText.DeRegister.nickname,
+                imgURL: $0.imgURL)
+            },
             isUserParticipatedIn: dto.isUserJoin
         )
     }
     
     private func convertToPaymentCard(_ dto: DTO.GetPaymentCard.PaymentCard) -> PaymentCardModels.FetchCard.Response.PaymentCard {
-        return .init(id: dto.id, totalAmount: dto.totalAmount, users: dto.users.map{.init(id: $0.id, isTaker: $0.isTaker, nickname: $0.nickname, imgURL: $0.imgURL)}, imgUrls: dto.imgUrls)
+        return .init(
+            id: dto.id,
+            totalAmount: dto.totalAmount,
+            users: dto.users.map{
+                .init(
+                    id: $0.id,
+                    isTaker: $0.isTaker,
+                    nickname: $0.nickname ?? ErrorText.DeRegister.nickname,
+                    imgURL: $0.imgURL
+                )
+            },
+            imgUrls: dto.imgUrls
+        )
     }
     
     // PaymentCardUserDTO에서 PaymentCardUser 도메인으로 변환해줍니다.
     private func convertToUser(_ dto: DTO.GetPaymentCardList.PaymentCard.User) -> PaymentCardModels.FetchCardList.Response.PaymentCard.User {
         return .init(
             id: dto.id,
-            nickname: dto.nickname,
+            nickname: dto.nickname ?? ErrorText.DeRegister.nickname,
             imgURL: dto.imgURL
         )
     }

--- a/Projects/DonWorry/Sources/Domain/Space/Repository/SpaceRepository.swift
+++ b/Projects/DonWorry/Sources/Domain/Space/Repository/SpaceRepository.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2022 Tr-iT. All rights reserved.
 //
 
+import Foundation
 import DonWorryNetworking
 import RxSwift
 
@@ -115,6 +116,11 @@ final class SpaceRepositoryImpl: SpaceRepository {
         return .init(id: dto.id, amount: dto.amount, isCompleted: dto.isCompleted, user: convert(from: dto.user))
     }
     private func convert(from dto: DTO.Space.User) -> SpaceModels.SpaceUser {
-        return .init(id: dto.id, nickname: dto.nickname, imgURL: dto.imgURL)
+        return .init(
+            id: dto.id,
+            nickname: dto.nickname ?? ErrorText.DeRegister.nickname,
+            imgURL: dto.imgURL
+        )
     }
 }
+

--- a/Projects/DonWorry/Sources/Global/Text/ErrorText.swift
+++ b/Projects/DonWorry/Sources/Global/Text/ErrorText.swift
@@ -1,0 +1,18 @@
+//
+//  ErrorText.swift
+//  DonWorryTests
+//
+//  Created by Woody on 2022/09/27.
+//  Copyright © 2022 Tr-iT. All rights reserved.
+//
+
+import Foundation
+
+struct ErrorText {
+    struct DeRegister {
+        static let nickname: String = "(알수없음)"
+        static let bankHolder: String = "(알수없음)"
+        static let bankNumber: String = "00000000000"
+        static let bank: String = "탈퇴한계좌"
+    }
+}

--- a/Projects/DonWorryNetworking/Sources/DTO/GetPaymentCardDTO.swift
+++ b/Projects/DonWorryNetworking/Sources/DTO/GetPaymentCardDTO.swift
@@ -19,7 +19,7 @@ extension DTO {
         public struct User: Codable {
             public let id: Int
             public let isTaker: Bool
-            public let nickname: String
+            public let nickname: String?
             public let imgURL: String?
 
             enum CodingKeys: String, CodingKey {

--- a/Projects/DonWorryNetworking/Sources/DTO/GetPaymentCardListDTO.swift
+++ b/Projects/DonWorryNetworking/Sources/DTO/GetPaymentCardListDTO.swift
@@ -36,14 +36,14 @@ extension DTO {
             public let totalAmount: Int
             public let bgColor, paymentDate: String
             public let category: Category
-            public let account: Account
+            public let account: Account?
             public let taker: User
             public let givers: [User]
             public let isUserJoin: Bool
 
             public struct User: Codable {
                 public let id: Int
-                public let nickname: String
+                public let nickname: String?
                 public let imgURL: String?
 
                 enum CodingKeys: String, CodingKey {
@@ -53,7 +53,7 @@ extension DTO {
             }
 
             public struct Account: Codable {
-                public let bank, number, holder: String
+                public let bank, number, holder: String?
 
                 enum CodingKeys: String, CodingKey {
                     case bank, number, holder

--- a/Projects/DonWorryNetworking/Sources/DTO/GetPaymentsGiverDTO.swift
+++ b/Projects/DonWorryNetworking/Sources/DTO/GetPaymentsGiverDTO.swift
@@ -13,9 +13,10 @@ extension DTO {
         public let paymentID, spaceID, amount, totalAmount: Int
         public let isCompleted: Bool
         public let takerNickname: String
-        public let account: Account
+        public let account: Account?
         public let cards: [Card]
         public let payments: [Payment]
+
         enum CodingKeys: String, CodingKey {
             case paymentID = "paymentId"
             case spaceID = "spaceId"
@@ -23,7 +24,7 @@ extension DTO {
         }
 
         public struct Account: Codable {
-            public let bank, number, holder: String
+            public let bank, number, holder: String?
         }
 
         public struct Card: Codable {
@@ -42,7 +43,7 @@ extension DTO {
         public struct Payment: Codable {
             public let id, amount: Int
             public let isCompleted: Bool
-            public let takerNickname: String
+            public let takerNickname: String?
         }
     }
 

--- a/Projects/DonWorryNetworking/Sources/DTO/GetPaymentsTakeDTO.swift
+++ b/Projects/DonWorryNetworking/Sources/DTO/GetPaymentsTakeDTO.swift
@@ -22,7 +22,7 @@ extension DTO {
         // MARK: - User
         public struct User: Codable {
             public let id: Int
-            public let nickname: String
+            public let nickname: String?
             public let imgURL: String?
 
             enum CodingKeys: String, CodingKey {

--- a/Projects/DonWorryNetworking/Sources/DTO/PatchUserDTO.swift
+++ b/Projects/DonWorryNetworking/Sources/DTO/PatchUserDTO.swift
@@ -14,10 +14,11 @@ extension DTO {
         public let nickname: String
         public let isAgreeMarketing: Bool
         public let imgUrl, tokenType, accessToken, refreshToken: String?
-        public let account: Account       
+        public let account: Account
+
         public struct Account: Codable {
             public let id: Int
-            public let bank, number, holder: String
+            public let bank, number, holder: String?
             public let userId: Int
 
             enum CodingKeys: String, CodingKey {

--- a/Projects/DonWorryNetworking/Sources/DTO/PostPaymentCardDTO.swift
+++ b/Projects/DonWorryNetworking/Sources/DTO/PostPaymentCardDTO.swift
@@ -15,7 +15,7 @@ extension DTO {
         public let totalAmount: Int
         public let bgColor, paymentDate: String
         public let category: Category
-        public let account: Account
+        public let account: Account?
 
         public enum CodingKeys: String, CodingKey {
             case id
@@ -35,7 +35,7 @@ extension DTO {
         }
         
         public struct Account: Codable {
-            public let bank, number, holder: String
+            public let bank, number, holder: String?
             public let userID: Int?
 
             public enum CodingKeys: String, CodingKey {

--- a/Projects/DonWorryNetworking/Sources/DTO/PostPaymentCardImageDTO.swift
+++ b/Projects/DonWorryNetworking/Sources/DTO/PostPaymentCardImageDTO.swift
@@ -14,7 +14,7 @@ extension DTO {
         public let name: String
         public let totalAmount: Int
         public let bgColor, paymentDate: String
-        public let account: Account
+        public let account: Account?
         public let imgUrls: [String]
 
         public enum CodingKeys: String, CodingKey {
@@ -26,7 +26,7 @@ extension DTO {
         }
         
         public struct Account: Codable {
-            public let bank, number, holder: String
+            public let bank, number, holder: String?
             public let userID: Int
 
             public enum CodingKeys: String, CodingKey {

--- a/Projects/DonWorryNetworking/Sources/DTO/PostUserDTO.swift
+++ b/Projects/DonWorryNetworking/Sources/DTO/PostUserDTO.swift
@@ -15,10 +15,10 @@ extension DTO {
         public let isAgreeMarketing: Bool
         public let tokenType, accessToken, refreshToken: String
         public let imgUrl: String?
-        public let account: Account
+        public let account: Account?
         
         public struct Account: Codable {
-            public let bank, number, holder: String
+            public let bank, number, holder: String?
             public let userID: Int
             
             public enum CodingKeys: String, CodingKey {

--- a/Projects/DonWorryNetworking/Sources/DTO/SpaceDTO.swift
+++ b/Projects/DonWorryNetworking/Sources/DTO/SpaceDTO.swift
@@ -36,7 +36,7 @@ extension DTO {
         // MARK: - User
         public struct User: Decodable {
             public let id: Int
-            public let nickname: String
+            public let nickname: String?
             public let imgURL: String?
 
             enum CodingKeys: String, CodingKey {


### PR DESCRIPTION
## 작업 사항

- 탈퇴한 사용자가 참여한 방일 경우, 사용자가 만든 컨텐츠(정산내역카드, 방)들을 지우는 것은 손실일 뿐더러 다른 정산 참여자들에게 필요한 정보들도 있기 때문에 탈퇴한 사용자들의 개인정보들만 지우기로 서버와 합의
- nickname, provider, providerId, account 정보들을 null처리하기로 함
- 이에 대응하여 DTO에서 해당 정보들을 optional처리 
- Domain으로 가져올 때 아래의 에러문구로 처리

```swift
struct ErrorText {
    struct DeRegister {
        static let nickname: String = "(알수없음)"
        static let bankHolder: String = "(알수없음)"
        static let bankNumber: String = "00000000000"
        static let bank: String = "탈퇴한계좌"
    }
}
```