### PR TITLE
♻️카드 금액 최대 10억으로 제한

### DIFF
--- a/Projects/DonWorry/Sources/UI/PaymentCardAmountEdit/PaymentCardAmountEditReactor.swift
+++ b/Projects/DonWorry/Sources/UI/PaymentCardAmountEdit/PaymentCardAmountEditReactor.swift
@@ -128,7 +128,7 @@ extension PaymentCardAmountEditReactor {
             } else {
                 _ = amount.popLast()
             }
-        } else if amount.count < 10 {
+        } else if amount.count < 9 {
             if amount == "0" {
                 amount = with
             } else {


### PR DESCRIPTION
## 작업사항 📝
카드 금액이 Int 최대값인 21억정도 이상이 되면 카드 생성이 안되는 이슈가 있었습니다.
최대 카드 금액을 10억 - 1원으로 제한하였습니다.